### PR TITLE
added range queries on sorted sets and improved integration tests

### DIFF
--- a/Func.Redis.Extensions/ServiceCollectionExtensions.cs
+++ b/Func.Redis.Extensions/ServiceCollectionExtensions.cs
@@ -118,7 +118,7 @@ public static class ServiceCollectionExtensions
                 s => s.AddSingleton<IRedisListService, RedisListService>(),
                 () => capabilities.HasFlag(RedisCapabilities.List))
             .TeeWhen(
-                s => s.Scan(selector => 
+                s => s.Scan(selector =>
                     selector
                         .FromAssemblies(assemblies)
                         .AddClasses(c => c.AssignableTo<IRedisSubscriber>())

--- a/Func.Redis/IRedisService.cs
+++ b/Func.Redis/IRedisService.cs
@@ -11,7 +11,7 @@ public interface IRedisService
     /// <returns>An <see cref="Either{Error, T}"/> containing either the result of the operation or an error if the operation
     /// fails.</returns>
     Either<Error, T> Execute<T>(Func<IDatabase, T> exec);
-    
+
     /// <summary>
     /// Executes a database operation and maps the result to a specified output type.
     /// </summary>
@@ -27,13 +27,13 @@ public interface IRedisService
     /// <returns>An <see cref="Either{TLeft, TRight}"/> containing either an <see cref="Error"/> if the operation fails,  or the
     /// mapped result of type <typeparamref name="TOut"/> if the operation succeeds.</returns>
     Either<Error, TOut> Execute<TIn, TOut>(Func<IDatabase, TIn> exec, Func<TIn, TOut> map);
-    
+
     /// <inheritdoc cref="Execute{T}(Func{IDatabase, T})"/>/>
     Task<Either<Error, T>> ExecuteAsync<T>(Func<IDatabase, Task<T>> exec);
-    
+
     /// <inheritdoc cref="Execute{TIn, TOut}(Func{IDatabase, TIn}, Func{TIn, TOut})"/>
     Task<Either<Error, TOut>> ExecuteAsync<TIn, TOut>(Func<IDatabase, Task<TIn>> exec, Func<TIn, TOut> map);
-    
+
     /// <summary>
     /// Executes an asynchronous operation on a database and maps the result to a specified output type.
     /// </summary>

--- a/Func.Redis/Publisher/IRedisPublisherService.cs
+++ b/Func.Redis/Publisher/IRedisPublisherService.cs
@@ -13,7 +13,7 @@ public interface IRedisPublisherService
     /// <returns>An <see cref="Either{Error, Unit}"/> indicating the result of the operation.  Returns <see langword="Unit"/> if
     /// the message is successfully published, or an <see cref="Error"/> if the operation fails.</returns>
     Either<Error, Unit> Publish(string channel, object message);
-    
+
     /// <inheritdoc cref="Publish(string, object)"/>
     Task<Either<Error, Unit>> PublishAsync(string channel, object message);
 }

--- a/Func.Redis/Set/IRedisSetService.cs
+++ b/Func.Redis/Set/IRedisSetService.cs
@@ -123,7 +123,7 @@ public interface IRedisSetService
     /// type <typeparamref name="T"/> representing the union of the values  associated with <paramref name="key1"/> and
     /// <paramref name="key2"/>.</returns>
     Either<Error, T[]> Union<T>(string key1, string key2);
- 
+
     /// <inheritdoc cref="Union{T}(string, string)"/>
     Task<Either<Error, T[]>> UnionAsync<T>(string key1, string key2);
 }

--- a/Func.Redis/SortedSet/IRedisSortedSetService.cs
+++ b/Func.Redis/SortedSet/IRedisSortedSetService.cs
@@ -10,7 +10,7 @@ public interface IRedisSortedSetService
     /// <param name="values"></param>
     /// <returns><see cref="Unit"/> or <see cref="Error"/></returns>
     Either<Error, Unit> Add<T>(string key, IEnumerable<(T Value, double Score)> values);
-    
+
     /// <summary>
     /// Add a value with score to a sorted set key.
     /// </summary>
@@ -37,7 +37,7 @@ public interface IRedisSortedSetService
 
     /// <inheritdoc cref="Decrement{T}(string, T, double)"/>
     Task<Either<Error, Unit>> DecrementAsync<T>(string key, T value, double score);
- 
+
     /// <summary>
     /// Increments the score associated with the specified key by the given value.
     /// </summary>
@@ -51,10 +51,10 @@ public interface IRedisSortedSetService
     /// <returns>An <see cref="Either{Error, Unit}"/> indicating the result of the operation. Returns <see langword="Unit"/> if
     /// the operation succeeds, or an <see cref="Error"/> if the operation fails.</returns>
     Either<Error, Unit> Increment<T>(string key, T value, double score);
- 
+
     /// <inheritdoc cref="Intersect{T}(string[])"/>
     Task<Either<Error, Unit>> IncrementAsync<T>(string key, T value, double score);
- 
+
     /// <summary>
     /// Retrieves the intersection of values associated with the specified keys.
     /// </summary>
@@ -66,7 +66,7 @@ public interface IRedisSortedSetService
 
     /// <inheritdoc cref="Intersect{T}(string[])"/>
     Task<Either<Error, T[]>> IntersectAsync<T>(string[] keys);
- 
+
     /// <summary>
     /// Retrieves the length of the value associated with the specified key.
     /// </summary>
@@ -74,7 +74,7 @@ public interface IRedisSortedSetService
     /// <returns>An <see cref="Either{TLeft, TRight}"/> containing either an <see cref="Error"/> if the operation fails,  or a
     /// <see langword="long"/> representing the length of the value if the operation succeeds.</returns>
     Either<Error, long> Length(string key);
- 
+
     /// <summary>
     /// Retrieves the count of elements in a sorted set stored at the specified key,  where the elements' scores fall
     /// within the given range.
@@ -87,13 +87,13 @@ public interface IRedisSortedSetService
     /// <returns>An <see cref="Either{Error, long}"/> containing either an error if the operation fails,  or the count of
     /// elements within the specified score range.</returns>
     Either<Error, long> LengthByScore(string key, double min, double max);
-  
+
     /// <inheritdoc cref="Length(string)"/>
     Task<Either<Error, long>> LengthAsync(string key);
-  
+
     /// <inheritdoc cref="LengthByScore(string, double, double)"/>
     Task<Either<Error, long>> LengthByScoreAsync(string key, double min, double max);
-  
+
     /// <summary>
     /// Retrieves the length of a collection stored under the specified key, filtered by a range of values.
     /// </summary>
@@ -107,7 +107,7 @@ public interface IRedisSortedSetService
     /// <returns>An <see cref="Either{TLeft, TRight}"/> containing either an <see cref="Error"/> if the operation fails,  or a
     /// <see langword="long"/> representing the count of items in the collection that fall within the specified range.</returns>
     Either<Error, long> LengthByValue<T>(string key, T min, T max);
- 
+
     /// <inheritdoc cref="LengthByValue{T}(string, T, T)"/>
     Task<Either<Error, long>> LengthByValueAsync<T>(string key, T min, T max);
 
@@ -124,10 +124,10 @@ public interface IRedisSortedSetService
     /// an <see cref="Option{T}"/> representing the rank of the value as a zero-based index.      Returns <see
     /// langword="None"/> if the value is not found in the collection.</returns>
     Either<Error, Option<long>> Rank<T>(string key, T value);
-  
+
     /// <inheritdoc cref="Rank{T}(string, T)"/>
     Task<Either<Error, Option<long>>> RankAsync<T>(string key, T value);
- 
+
     /// <summary>
     /// Removes the specified values associated with the given key from the collection.
     /// </summary>
@@ -137,7 +137,7 @@ public interface IRedisSortedSetService
     /// <returns>An <see cref="Either{Error, Unit}"/> indicating the result of the operation.  Returns <see langword="Unit"/> if
     /// the removal is successful, or an <see cref="Error"/> if the operation fails.</returns>
     Either<Error, Unit> Remove<T>(string key, IEnumerable<T> values);
- 
+
     /// <summary>
     /// Removes the specified value associated with the given key from the collection.
     /// </summary>
@@ -149,13 +149,13 @@ public interface IRedisSortedSetService
     /// <returns>An <see cref="Either{Error, Unit}"/> indicating the result of the operation.  Returns <see langword="Unit"/> if
     /// the removal is successful, or an <see cref="Error"/> if the operation fails.</returns>
     Either<Error, Unit> Remove<T>(string key, T value);
- 
+
     /// <inheritdoc cref="Remove{T}(string, IEnumerable{T})"/>
     Task<Either<Error, Unit>> RemoveAsync<T>(string key, IEnumerable<T> values);
-  
+
     /// <inheritdoc cref="Remove{T}(string, T)"/>
     Task<Either<Error, Unit>> RemoveAsync<T>(string key, T value);
- 
+
     /// <summary>
     /// Removes all elements in the sorted set stored at the specified key with scores within the given range.
     /// </summary>
@@ -167,10 +167,10 @@ public interface IRedisSortedSetService
     /// <returns>An <see cref="Either{Error, Unit}"/> indicating the result of the operation.  Returns <see langword="Unit"/> if
     /// the operation succeeds, or an <see cref="Error"/> if it fails.</returns>
     Either<Error, Unit> RemoveRangeByScore(string key, double start, double stop);
- 
+
     /// <inheritdoc cref="RemoveRangeByScore(string, double, double)"/>
     Task<Either<Error, Unit>> RemoveRangeByScoreAsync(string key, double start, double stop);
- 
+
     /// <summary>
     /// Removes a range of values from a data store based on the specified key and value range.
     /// </summary>
@@ -187,7 +187,7 @@ public interface IRedisSortedSetService
 
     /// <inheritdoc cref="RemoveRangeByValue{T}(string, T, T)"/>
     Task<Either<Error, Unit>> RemoveRangeByValueAsync<T>(string key, T min, T max);
- 
+
     /// <summary>
     /// Calculates a score based on the provided key and value, returning either an error or an optional score.
     /// </summary>
@@ -198,7 +198,7 @@ public interface IRedisSortedSetService
     /// or an <see cref="Option{double}"/> representing the calculated score. The score may be absent if no valid result
     /// is produced.</returns>
     Either<Error, Option<double>> Score<T>(string key, T value);
- 
+
     /// <inheritdoc cref="Score{T}(string, T)"/>
     Task<Either<Error, Option<double>>> ScoreAsync<T>(string key, T value);
 
@@ -213,4 +213,19 @@ public interface IRedisSortedSetService
 
     /// <inheritdoc cref="Union{T}(string[])"/>
     Task<Either<Error, T[]>> UnionAsync<T>(string[] keys);
+
+    /// <summary>
+    /// Retrieves a range of elements from a sorted collection based on their score values.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the collection.</typeparam>
+    /// <param name="key">The key identifying the sorted collection. Cannot be null or empty.</param>
+    /// <param name="min">The minimum score value for the range. Elements with scores less than this value are excluded.</param>
+    /// <param name="max">The maximum score value for the range. Elements with scores greater than this value are excluded.</param>
+    /// <returns>An <see cref="Either{TLeft, TRight}"/> containing either an <see cref="Error"/> if the operation fails,  or an
+    /// array of elements of type <typeparamref name="T"/> that fall within the specified score range. If no elements
+    /// match the criteria, an empty array is returned.</returns>
+    Either<Error, T[]> RangeByScore<T>(string key, double min, double max);
+
+    /// <inheritdoc cref="RangeByScore{T}(string, double, double)"/>
+    Task<Either<Error, T[]>> RangeByScoreAsync<T>(string key, double min, double max);
 }

--- a/Func.Redis/SortedSet/KeyTransformerRedisSortedSetService.cs
+++ b/Func.Redis/SortedSet/KeyTransformerRedisSortedSetService.cs
@@ -16,14 +16,16 @@ public class KeyTransformerRedisSortedSetService(
     public Task<Either<Error, Unit>> DecrementAsync<T>(string key, T value, double score) => _service.DecrementAsync(_keyMapper(key), value, score);
     public Either<Error, Unit> Increment<T>(string key, T value, double score) => _service.Increment(_keyMapper(key), value, score);
     public Task<Either<Error, Unit>> IncrementAsync<T>(string key, T value, double score) => _service.IncrementAsync(_keyMapper(key), value, score);
-    public Either<Error, T[]> Intersect<T>(string[] keys) => _service.Intersect<T>(keys.Select(_keyMapper).ToArray());
-    public Task<Either<Error, T[]>> IntersectAsync<T>(string[] keys) => _service.IntersectAsync<T>(keys.Select(_keyMapper).ToArray());
+    public Either<Error, T[]> Intersect<T>(string[] keys) => _service.Intersect<T>([.. keys.Select(_keyMapper)]);
+    public Task<Either<Error, T[]>> IntersectAsync<T>(string[] keys) => _service.IntersectAsync<T>([.. keys.Select(_keyMapper)]);
     public Either<Error, long> Length(string key) => _service.Length(_keyMapper(key));
     public Task<Either<Error, long>> LengthAsync(string key) => _service.LengthAsync(_keyMapper(key));
     public Either<Error, long> LengthByScore(string key, double min, double max) => _service.LengthByScore(_keyMapper(key), min, max);
     public Task<Either<Error, long>> LengthByScoreAsync(string key, double min, double max) => _service.LengthByScoreAsync(_keyMapper(key), min, max);
     public Either<Error, long> LengthByValue<T>(string key, T min, T max) => _service.LengthByValue(_keyMapper(key), min, max);
     public Task<Either<Error, long>> LengthByValueAsync<T>(string key, T min, T max) => _service.LengthByValueAsync(_keyMapper(key), min, max);
+    public Either<Error, T[]> RangeByScore<T>(string key, double min, double max) => _service.RangeByScore<T>(_keyMapper(key), min, max);
+    public Task<Either<Error, T[]>> RangeByScoreAsync<T>(string key, double min, double max) => _service.RangeByScoreAsync<T>(_keyMapper(key), min, max);
     public Either<Error, Option<long>> Rank<T>(string key, T value) => _service.Rank(_keyMapper(key), value);
     public Task<Either<Error, Option<long>>> RankAsync<T>(string key, T value) => _service.RankAsync(_keyMapper(key), value);
     public Either<Error, Unit> Remove<T>(string key, IEnumerable<T> values) => _service.Remove(_keyMapper(key), values);
@@ -36,6 +38,6 @@ public class KeyTransformerRedisSortedSetService(
     public Task<Either<Error, Unit>> RemoveRangeByValueAsync<T>(string key, T min, T max) => _service.RemoveRangeByValueAsync(_keyMapper(key), min, max);
     public Either<Error, Option<double>> Score<T>(string key, T value) => _service.Score(_keyMapper(key), value);
     public Task<Either<Error, Option<double>>> ScoreAsync<T>(string key, T value) => _service.ScoreAsync(_keyMapper(key), value);
-    public Either<Error, T[]> Union<T>(string[] keys) => _service.Union<T>(keys.Select(_keyMapper).ToArray());
-    public Task<Either<Error, T[]>> UnionAsync<T>(string[] keys) => _service.UnionAsync<T>(keys.Select(_keyMapper).ToArray());
+    public Either<Error, T[]> Union<T>(string[] keys) => _service.Union<T>([.. keys.Select(_keyMapper)]);
+    public Task<Either<Error, T[]>> UnionAsync<T>(string[] keys) => _service.UnionAsync<T>([.. keys.Select(_keyMapper)]);
 }

--- a/Func.Redis/SortedSet/LoggingRedisSortedSetService.cs
+++ b/Func.Redis/SortedSet/LoggingRedisSortedSetService.cs
@@ -190,4 +190,16 @@ internal class LoggingRedisSortedSetService(
             .Tee(k => _logger.LogInformation("{Component}: async union of keys [{Keys}]", ComponentName, string.Join(", ", k)))
             .Map(_service.UnionAsync<T>)
             .TeeLog(_logger, ComponentName);
+
+    public Either<Error, T[]> RangeByScore<T>(string key, double min, double max) =>
+        (key, min, max)
+            .Tee(t => _logger.LogInformation("{Component}: getting range by score from sorted set at \"{Key}\" with range [{Min}, {Max}]", ComponentName, t.key, t.min, t.max))
+            .Map(t => _service.RangeByScore<T>(t.key, t.min, t.max))
+            .TeeLog(_logger, ComponentName);
+
+    public Task<Either<Error, T[]>> RangeByScoreAsync<T>(string key, double min, double max) =>
+        (key, min, max)
+            .Tee(t => _logger.LogInformation("{Component}: async getting range by score from sorted set at \"{Key}\" with range [{Min}, {Max}]", ComponentName, t.key, t.min, t.max))
+            .Map(t => _service.RangeByScoreAsync<T>(t.key, t.min, t.max))
+            .TeeLog(_logger, ComponentName);
 }

--- a/Func.Redis/SortedSet/RedisSortedSetService.cs
+++ b/Func.Redis/SortedSet/RedisSortedSetService.cs
@@ -108,4 +108,10 @@ public class RedisSortedSetService(
 
     private Task<Either<Error, T[]>> CombineAsync<T>(string[] keys, SetOperation operation) =>
         WrapUnsafeAsync(() => _database.SortedSetCombineAsync(operation, [.. keys.Select(k => (RedisKey)k)]), vs => vs.Select(_serDes.Deserialize<T>).Filter().ToArray());
+
+    public Either<Error, T[]> RangeByScore<T>(string key, double min, double max) =>
+        Wrap(() => _database.SortedSetRangeByScore(key, min, max).Select(_serDes.Deserialize<T>).Filter().ToArray());
+
+    public Task<Either<Error, T[]>> RangeByScoreAsync<T>(string key, double min, double max) =>
+        WrapUnsafeAsync(() => _database.SortedSetRangeByScoreAsync(key, min, max), vs => vs.Select(_serDes.Deserialize<T>).Filter().ToArray());
 }

--- a/tests/Func.Redis.Extensions.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Func.Redis.Extensions.Tests/ServiceCollectionExtensionsTests.cs
@@ -37,15 +37,12 @@ internal class ServiceCollectionExtensionsTests
     private IServiceCollection _mockServices;
 
     internal static readonly RedisCapabilities[] AllCapabilities =
-        Enumerable
+        [.. Enumerable
             .Range(1, Enum.GetValues<RedisCapabilities>().Select(c => (int)c).Max() << 1 - 1)
-            .Select(i => (RedisCapabilities)i)
-            .ToArray();
+            .Select(i => (RedisCapabilities)i)];
 
     internal static readonly object[][] InvalidConfigAndAllCapabilities =
-        new[] { "", null }
-            .Map(inv => AllCapabilities.SelectMany(c => inv.Select(i => new object[] { i, c })))
-            .ToArray();
+        [.. new[] { "", null }.Map(inv => AllCapabilities.SelectMany(c => inv.Select(i => new object[] { i, c })))];
 
     [SetUp]
     public void SetUp()
@@ -262,7 +259,7 @@ internal class ServiceCollectionExtensionsTests
             Type expectedKeyType,
             Type expectedImplementationType)
     {
-        
+
         var config = new MemoryConfigurationSource
         {
             InitialData = new Dictionary<string, string>
@@ -270,7 +267,7 @@ internal class ServiceCollectionExtensionsTests
                 {"RedisConfiguration:ConnectionString", "whatever"}
             }
         };
-        
+
         _mockServices
             .AddRedis<StubSerdes>(new ConfigurationBuilder().Add(config).Build(), capabilities, false, Assembly.GetExecutingAssembly());
 

--- a/tests/Func.Redis.IntegrationTests/HashSet/RedisHashSetServiceIntegrationTest_Redis_8.cs
+++ b/tests/Func.Redis.IntegrationTests/HashSet/RedisHashSetServiceIntegrationTest_Redis_8.cs
@@ -1,0 +1,6 @@
+﻿namespace Func.Redis.IntegrationTests.HashSet;
+
+internal class RedisHashSetServiceIntegrationTest_Redis_8 : RedisHashSetServiceIntegrationTest
+{
+    public RedisHashSetServiceIntegrationTest_Redis_8() : base("redis:8") { }
+}

--- a/tests/Func.Redis.IntegrationTests/HashSet/RedisHashSetServiceIntegrationTest_Redis_8_Alpine.cs
+++ b/tests/Func.Redis.IntegrationTests/HashSet/RedisHashSetServiceIntegrationTest_Redis_8_Alpine.cs
@@ -1,0 +1,6 @@
+﻿namespace Func.Redis.IntegrationTests.HashSet;
+
+internal class RedisHashSetServiceIntegrationTest_Redis_8_Alpine : RedisHashSetServiceIntegrationTest
+{
+    public RedisHashSetServiceIntegrationTest_Redis_8_Alpine() : base("redis:8-alpine") { }
+}

--- a/tests/Func.Redis.IntegrationTests/Key/RedisKeyServiceIntegrationTest_Redis_8_0.cs
+++ b/tests/Func.Redis.IntegrationTests/Key/RedisKeyServiceIntegrationTest_Redis_8_0.cs
@@ -1,0 +1,6 @@
+﻿namespace Func.Redis.IntegrationTests.Key;
+
+internal class RedisKeyServiceIntegrationTest_Redis_8_0 : RedisKeyServiceIntegrationTest
+{
+    public RedisKeyServiceIntegrationTest_Redis_8_0() : base("redis:8") { }
+}

--- a/tests/Func.Redis.IntegrationTests/Key/RedisKeyServiceIntegrationTest_Redis_8_Alpine.cs
+++ b/tests/Func.Redis.IntegrationTests/Key/RedisKeyServiceIntegrationTest_Redis_8_Alpine.cs
@@ -1,0 +1,6 @@
+﻿namespace Func.Redis.IntegrationTests.Key;
+
+internal class RedisKeyServiceIntegrationTest_Redis_8_Alpine : RedisKeyServiceIntegrationTest
+{
+    public RedisKeyServiceIntegrationTest_Redis_8_Alpine() : base("redis:8-alpine") { }
+}

--- a/tests/Func.Redis.IntegrationTests/List/RedisListServiceIntegrationTests_Redis_8_0.cs
+++ b/tests/Func.Redis.IntegrationTests/List/RedisListServiceIntegrationTests_Redis_8_0.cs
@@ -1,0 +1,6 @@
+﻿namespace Func.Redis.IntegrationTests.List;
+
+internal class RedisListServiceIntegrationTests_Redis_8_0 : RedisListServiceIntegrationTests
+{
+    public RedisListServiceIntegrationTests_Redis_8_0() : base("redis:8") { }
+}

--- a/tests/Func.Redis.IntegrationTests/List/RedisListServiceIntegrationTests_Redis_8_Alpine.cs
+++ b/tests/Func.Redis.IntegrationTests/List/RedisListServiceIntegrationTests_Redis_8_Alpine.cs
@@ -1,0 +1,6 @@
+﻿namespace Func.Redis.IntegrationTests.List;
+
+internal class RedisListServiceIntegrationTests_Redis_8_Alpine : RedisListServiceIntegrationTests
+{
+    public RedisListServiceIntegrationTests_Redis_8_Alpine() : base("redis:8-alpine") { }
+}

--- a/tests/Func.Redis.IntegrationTests/PubSub/PubSubIntegrationTest_Redis_8_0.cs
+++ b/tests/Func.Redis.IntegrationTests/PubSub/PubSubIntegrationTest_Redis_8_0.cs
@@ -1,0 +1,7 @@
+﻿namespace Func.Redis.IntegrationTests.PubSub;
+
+internal class PubSubIntegrationTest_Redis_8_0 : PubSubIntegrationTest
+{
+    public PubSubIntegrationTest_Redis_8_0() : base("redis:8") { }
+}
+

--- a/tests/Func.Redis.IntegrationTests/PubSub/PubSubIntegrationTest_Redis_8_Alpine.cs
+++ b/tests/Func.Redis.IntegrationTests/PubSub/PubSubIntegrationTest_Redis_8_Alpine.cs
@@ -1,0 +1,7 @@
+﻿namespace Func.Redis.IntegrationTests.PubSub;
+
+internal class PubSubIntegrationTest_Redis_8_Alpine : PubSubIntegrationTest
+{
+    public PubSubIntegrationTest_Redis_8_Alpine() : base("redis:8-alpine") { }
+}
+

--- a/tests/Func.Redis.IntegrationTests/Set/RedisSetServiceIntegrationTest.cs
+++ b/tests/Func.Redis.IntegrationTests/Set/RedisSetServiceIntegrationTest.cs
@@ -67,8 +67,8 @@ internal abstract class RedisSetServiceIntegrationTest(string redisImage) : Redi
     [Test]
     public async Task WhenDataArePresentInDifferentSets_CombineOperationShouldReturnExpectedResults()
     {
-        var key1 = $"{WhenDataArePresentInDifferentSets_CombineOperationShouldReturnExpectedResults}_1";
-        var key2 = $"{WhenDataArePresentInDifferentSets_CombineOperationShouldReturnExpectedResults}_2";
+        var key1 = $"{nameof(WhenDataArePresentInDifferentSets_CombineOperationShouldReturnExpectedResults)}_1";
+        var key2 = $"{nameof(WhenDataArePresentInDifferentSets_CombineOperationShouldReturnExpectedResults)}_2";
 
         var input1 = new TestModel
         {

--- a/tests/Func.Redis.IntegrationTests/Set/RedisSetServiceIntegrationTest_Redis_8_0.cs
+++ b/tests/Func.Redis.IntegrationTests/Set/RedisSetServiceIntegrationTest_Redis_8_0.cs
@@ -1,0 +1,6 @@
+﻿namespace Func.Redis.IntegrationTests.Set;
+
+internal class RedisSetServiceIntegrationTest_Redis_8_0 : RedisSetServiceIntegrationTest
+{
+    public RedisSetServiceIntegrationTest_Redis_8_0() : base("redis:8") { }
+}

--- a/tests/Func.Redis.IntegrationTests/Set/RedisSetServiceIntegrationTest_Redis_8_Alpine.cs
+++ b/tests/Func.Redis.IntegrationTests/Set/RedisSetServiceIntegrationTest_Redis_8_Alpine.cs
@@ -1,0 +1,6 @@
+﻿namespace Func.Redis.IntegrationTests.Set;
+
+internal class RedisSetServiceIntegrationTest_Redis_8_Alpine : RedisSetServiceIntegrationTest
+{
+    public RedisSetServiceIntegrationTest_Redis_8_Alpine() : base("redis:8-alpine") { }
+}

--- a/tests/Func.Redis.IntegrationTests/SortedSet/RedisSortedSetServiceIntegrationTest.cs
+++ b/tests/Func.Redis.IntegrationTests/SortedSet/RedisSortedSetServiceIntegrationTest.cs
@@ -1,0 +1,116 @@
+﻿using Func.Redis.SortedSet;
+
+namespace Func.Redis.IntegrationTests.SortedSet;
+
+internal abstract class RedisSortedSetServiceIntegrationTest(string redisImage) : RedisIntegrationTestBase(redisImage)
+{
+    private RedisSortedSetService _sut;
+
+    [OneTimeSetUp]
+    public override async Task OneTimeSetUp()
+    {
+        await base.OneTimeSetUp();
+
+        _sut = _provider.Map(sp => new RedisSortedSetService(sp, new SystemJsonRedisSerDes()));
+    }
+
+    [Test]
+    public async Task WhenDataAreNotPresent_AddShouldReturnRightUnit()
+    {
+        var addResult = await _sut.AddAsync("some key", "some value", 10);
+
+        addResult.IsRight.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task WhenDataAreSuccessfullyAdded_TheyShouldBeSuccessfullyRetrieved()
+    {
+        var key = nameof(WhenDataAreSuccessfullyAdded_TheyShouldBeSuccessfullyRetrieved);
+
+        var input = new TestModel
+        {
+            Id = Guid.NewGuid()
+        };
+
+        var addResult = await _sut.AddAsync(key, input, 1);
+        addResult.IsRight.Should().BeTrue();
+
+        var lengthResult = await _sut.LengthAsync(key);
+
+        lengthResult.IsRight.Should().BeTrue();
+        lengthResult.OnRight(o => o.Should().Be(1));
+
+        var input2 = new TestModel
+        {
+            Id = Guid.NewGuid()
+        };
+
+        addResult = await _sut.AddAsync(key, input2, 10);
+        addResult.IsRight.Should().BeTrue();
+
+        lengthResult = await _sut.LengthAsync(key);
+
+        lengthResult.IsRight.Should().BeTrue();
+        lengthResult.OnRight(o => o.Should().Be(2));
+
+        var rangeResult = await _sut.RangeByScoreAsync<TestModel>(key, 1, 5);
+        rangeResult.IsRight.Should().BeTrue();
+        rangeResult.OnRight(o => o.Should().BeEquivalentTo([input]));
+
+        rangeResult = await _sut.RangeByScoreAsync<TestModel>(key, 1, 10);
+        rangeResult.IsRight.Should().BeTrue();
+        rangeResult.OnRight(o => o.Should().BeEquivalentTo([input, input2]));
+    }
+
+    [Test]
+    public async Task WhenDataArePresentInDifferentSets_CombineOperationShouldReturnExpectedResults()
+    {
+        var key1 = $"{nameof(WhenDataArePresentInDifferentSets_CombineOperationShouldReturnExpectedResults)}_1";
+        var key2 = $"{nameof(WhenDataArePresentInDifferentSets_CombineOperationShouldReturnExpectedResults)}_2";
+
+        var input1 = new TestModel
+        {
+            Id = Guid.NewGuid()
+        };
+        var input2 = new TestModel
+        {
+            Id = Guid.NewGuid()
+        };
+        var input3 = new TestModel
+        {
+            Id = Guid.NewGuid()
+        };
+        var input4 = new TestModel
+        {
+            Id = Guid.NewGuid()
+        };
+        var input5 = new TestModel
+        {
+            Id = Guid.NewGuid()
+        };
+
+        var addResult1 = await _sut.AddAsync(key1, input1, 1)
+            .BindAsync(_ => _sut.AddAsync(key1, input2, 2))
+            .BindAsync(_ => _sut.AddAsync(key1, input3, 3))
+            .BindAsync(_ => _sut.AddAsync(key1, input4, 4));
+
+        addResult1.IsRight.Should().BeTrue();
+
+        var addResult2 = await _sut.AddAsync(key2, input3, 10)
+            .BindAsync(_ => _sut.AddAsync(key2, input4, 11))
+            .BindAsync(_ => _sut.AddAsync(key2, input5, 12));
+
+        addResult2.IsRight.Should().BeTrue();
+
+        var keys = new[] { key1, key2 };
+        var intersectResult = await _sut.IntersectAsync<TestModel>(keys);
+
+        intersectResult.IsRight.Should().BeTrue();
+        intersectResult.OnRight(o => o.Should().BeEquivalentTo([input3, input4]));
+
+        var unionResult = await _sut.UnionAsync<TestModel>(keys);
+
+        unionResult.IsRight.Should().BeTrue();
+        unionResult.OnRight(o => o.Should().BeEquivalentTo([input1, input2, input3, input4, input5]));
+    }
+}

--- a/tests/Func.Redis.IntegrationTests/SortedSet/RedisSortedSetServiceIntegrationTest_Redis_6_0.cs
+++ b/tests/Func.Redis.IntegrationTests/SortedSet/RedisSortedSetServiceIntegrationTest_Redis_6_0.cs
@@ -1,0 +1,6 @@
+﻿namespace Func.Redis.IntegrationTests.SortedSet;
+
+internal class RedisSortedSetServiceIntegrationTest_Redis_6_0 : RedisSortedSetServiceIntegrationTest
+{
+    public RedisSortedSetServiceIntegrationTest_Redis_6_0() : base("redis:6") { }
+}

--- a/tests/Func.Redis.IntegrationTests/SortedSet/RedisSortedSetServiceIntegrationTest_Redis_6_Alpine.cs
+++ b/tests/Func.Redis.IntegrationTests/SortedSet/RedisSortedSetServiceIntegrationTest_Redis_6_Alpine.cs
@@ -1,0 +1,6 @@
+﻿namespace Func.Redis.IntegrationTests.SortedSet;
+
+internal class RedisSortedSetServiceIntegrationTest_Redis_6_Alpine : RedisSortedSetServiceIntegrationTest
+{
+    public RedisSortedSetServiceIntegrationTest_Redis_6_Alpine() : base("redis:6-alpine") { }
+}

--- a/tests/Func.Redis.IntegrationTests/SortedSet/RedisSortedSetServiceIntegrationTest_Redis_7_0.cs
+++ b/tests/Func.Redis.IntegrationTests/SortedSet/RedisSortedSetServiceIntegrationTest_Redis_7_0.cs
@@ -1,0 +1,6 @@
+﻿namespace Func.Redis.IntegrationTests.SortedSet;
+
+internal class RedisSortedSetServiceIntegrationTest_Redis_7_0 : RedisSortedSetServiceIntegrationTest
+{
+    public RedisSortedSetServiceIntegrationTest_Redis_7_0() : base("redis:7") { }
+}

--- a/tests/Func.Redis.IntegrationTests/SortedSet/RedisSortedSetServiceIntegrationTest_Redis_7_Alpine.cs
+++ b/tests/Func.Redis.IntegrationTests/SortedSet/RedisSortedSetServiceIntegrationTest_Redis_7_Alpine.cs
@@ -1,0 +1,6 @@
+﻿namespace Func.Redis.IntegrationTests.SortedSet;
+
+internal class RedisSortedSetServiceIntegrationTest_Redis_7_Alpine : RedisSortedSetServiceIntegrationTest
+{
+    public RedisSortedSetServiceIntegrationTest_Redis_7_Alpine() : base("redis:7-alpine") { }
+}

--- a/tests/Func.Redis.IntegrationTests/SortedSet/RedisSortedSetServiceIntegrationTest_Redis_8_0 .cs
+++ b/tests/Func.Redis.IntegrationTests/SortedSet/RedisSortedSetServiceIntegrationTest_Redis_8_0 .cs
@@ -1,0 +1,6 @@
+﻿namespace Func.Redis.IntegrationTests.SortedSet;
+
+internal class RedisSortedSetServiceIntegrationTest_Redis_8_0 : RedisSortedSetServiceIntegrationTest
+{
+    public RedisSortedSetServiceIntegrationTest_Redis_8_0() : base("redis:8") { }
+}

--- a/tests/Func.Redis.IntegrationTests/SortedSet/RedisSortedSetServiceIntegrationTest_Redis_8_Alpine.cs
+++ b/tests/Func.Redis.IntegrationTests/SortedSet/RedisSortedSetServiceIntegrationTest_Redis_8_Alpine.cs
@@ -1,0 +1,6 @@
+﻿namespace Func.Redis.IntegrationTests.SortedSet;
+
+internal class RedisSortedSetServiceIntegrationTest_Redis_8_Alpine : RedisSortedSetServiceIntegrationTest
+{
+    public RedisSortedSetServiceIntegrationTest_Redis_8_Alpine() : base("redis:8-alpine") { }
+}

--- a/tests/Func.Redis.IntegrationTests/SortedSet/RedisSortedSetServiceIntegrationTest_Valkey_8.cs
+++ b/tests/Func.Redis.IntegrationTests/SortedSet/RedisSortedSetServiceIntegrationTest_Valkey_8.cs
@@ -1,0 +1,6 @@
+﻿namespace Func.Redis.IntegrationTests.SortedSet;
+
+internal class RedisSortedSetServiceIntegrationTest_Valkey_8 : RedisSortedSetServiceIntegrationTest
+{
+    public RedisSortedSetServiceIntegrationTest_Valkey_8() : base("valkey/valkey:8") { }
+}

--- a/tests/Func.Redis.Tests/SortedSet/KeyTransformerRedisSortedSetServiceTests.cs
+++ b/tests/Func.Redis.Tests/SortedSet/KeyTransformerRedisSortedSetServiceTests.cs
@@ -382,4 +382,30 @@ internal class KeyTransformerRedisSortedSetServiceTests
         result.Should().Be(internalResult);
         await _mockService.Received(1).ScoreAsync("mapped_key", "value");
     }
+
+    [TestCaseSource(typeof(TestDataElements), nameof(ErrorStringsTestData))]
+    public void RangeByScore_ShouldCallServiceWithMappedKey(Either<Error, string[]> internalResult)
+    {
+        var key = "key";
+        _mockService.RangeByScore<string>("mapped_key", 1.0, 10.0).Returns(internalResult);
+
+        var result = _sut.RangeByScore<string>(key, 1.0, 10.0);
+
+        result.Should().Be(internalResult);
+        _mockService.Received(1).RangeByScore<string>("mapped_key", 1.0, 10.0);
+    }
+
+    [TestCaseSource(typeof(TestDataElements), nameof(ErrorStringsTestData))]
+    public async Task RangeByScoreAsync_ShouldCallServiceWithMappedKey(Either<Error, string[]> internalResult)
+    {
+        var key = "key";
+        _mockService
+            .RangeByScoreAsync<string>("mapped_key", 1.0, 10.0)
+            .Returns(internalResult);
+
+        var result = await _sut.RangeByScoreAsync<string>(key, 1.0, 10.0);
+
+        result.Should().Be(internalResult);
+        await _mockService.Received(1).RangeByScoreAsync<string>("mapped_key", 1.0, 10.0);
+    }
 }

--- a/tests/Func.Redis.Tests/SortedSet/LoggingRedisSortedSetService/LoggingRedisSortedSetServiceTests.Add.cs
+++ b/tests/Func.Redis.Tests/SortedSet/LoggingRedisSortedSetService/LoggingRedisSortedSetServiceTests.Add.cs
@@ -77,12 +77,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .AddAsync("some key", "value", 10)
             .Returns(Either<Error, Unit>.Left(error));
-        
+
         var result = await _sut.AddAsync("some key", "value", 10);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -110,9 +110,9 @@ internal partial class LoggingRedisSortedSetServiceTests
             .Returns(Unit.Default);
 
         var result = _sut.Add("some key", data);
-        
+
         result.IsRight.Should().BeTrue();
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(1);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -134,9 +134,9 @@ internal partial class LoggingRedisSortedSetServiceTests
             .AddAsync("some key", data)
             .Returns(Either<Error, Unit>.Right(Unit.Default));
         var result = await _sut.AddAsync("some key", data);
-        
+
         result.IsRight.Should().BeTrue();
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(1);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -159,10 +159,10 @@ internal partial class LoggingRedisSortedSetServiceTests
             .Add("some key", data)
             .Returns(error);
         var result = _sut.Add("some key", data);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -189,12 +189,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .AddAsync("some key", data)
             .Returns(Either<Error, Unit>.Left(error));
-        
+
         var result = await _sut.AddAsync("some key", data);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>

--- a/tests/Func.Redis.Tests/SortedSet/LoggingRedisSortedSetService/LoggingRedisSortedSetServiceTests.Increment.cs
+++ b/tests/Func.Redis.Tests/SortedSet/LoggingRedisSortedSetService/LoggingRedisSortedSetServiceTests.Increment.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Func.Redis.Tests.SortedSet.LoggingRedisSortedSetService;
+﻿namespace Func.Redis.Tests.SortedSet.LoggingRedisSortedSetService;
 internal partial class LoggingRedisSortedSetServiceTests
 {
     [Test]
@@ -15,9 +9,9 @@ internal partial class LoggingRedisSortedSetServiceTests
             .Returns(Unit.Default);
 
         var result = _sut.Increment("some key", "value", 10);
-        
+
         result.IsRight.Should().BeTrue();
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(1);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -54,12 +48,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .Increment("some key", "value", 10)
             .Returns(error);
-        
+
         var result = _sut.Increment("some key", "value", 10);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -81,12 +75,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .IncrementAsync("some key", "value", 10)
             .Returns(error);
-        
+
         var result = await _sut.IncrementAsync("some key", "value", 10);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>

--- a/tests/Func.Redis.Tests/SortedSet/LoggingRedisSortedSetService/LoggingRedisSortedSetServiceTests.Intersect.cs
+++ b/tests/Func.Redis.Tests/SortedSet/LoggingRedisSortedSetService/LoggingRedisSortedSetServiceTests.Intersect.cs
@@ -11,7 +11,7 @@ internal partial class LoggingRedisSortedSetServiceTests
             .Returns(data);
 
         var result = _sut.Intersect<object>(keys);
-        
+
         result.IsRight.Should().BeTrue();
         result.OnRight(values => values.Should().BeEquivalentTo(data));
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
@@ -31,9 +31,9 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .IntersectAsync<object>(keys)
             .Returns(data);
-     
+
         var result = await _sut.IntersectAsync<object>(keys);
-        
+
         result.IsRight.Should().BeTrue();
         result.OnRight(values => values.Should().BeEquivalentTo(data));
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
@@ -54,10 +54,10 @@ internal partial class LoggingRedisSortedSetServiceTests
             .Intersect<object>(keys)
             .Returns(error);
         var result = _sut.Intersect<object>(keys);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -80,12 +80,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .IntersectAsync<object>(keys)
             .Returns(error);
-        
+
         var result = await _sut.IntersectAsync<object>(keys);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>

--- a/tests/Func.Redis.Tests/SortedSet/LoggingRedisSortedSetService/LoggingRedisSortedSetServiceTests.Length.cs
+++ b/tests/Func.Redis.Tests/SortedSet/LoggingRedisSortedSetService/LoggingRedisSortedSetServiceTests.Length.cs
@@ -103,9 +103,9 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .LengthByScore("key", 1, 10)
             .Returns(5);
-        
+
         var result = _sut.LengthByScore("key", 1, 10);
-        
+
         result.IsRight.Should().BeTrue();
         result.OnRight(l => l.Should().Be(5));
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
@@ -124,12 +124,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .LengthByScore("key", 1, 10)
             .Returns(error);
-        
+
         var result = _sut.LengthByScore("key", 1, 10);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -150,12 +150,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .LengthByScoreAsync("key", 1, 10)
             .Returns(5);
-        
+
         var result = await _sut.LengthByScoreAsync("key", 1, 10);
-        
+
         result.IsRight.Should().BeTrue();
         result.OnRight(l => l.Should().Be(5));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(1);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -172,12 +172,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .LengthByScoreAsync("key", 1, 10)
             .Returns(error);
-        
+
         var result = await _sut.LengthByScoreAsync("key", 1, 10);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -198,12 +198,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .LengthByValue("key", 1, 10)
             .Returns(5);
-        
+
         var result = _sut.LengthByValue("key", 1, 10);
-        
+
         result.IsRight.Should().BeTrue();
         result.OnRight(l => l.Should().Be(5));
-     
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(1);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -220,12 +220,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .LengthByValue("key", 1, 10)
             .Returns(error);
-        
+
         var result = _sut.LengthByValue("key", 1, 10);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -246,12 +246,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .LengthByValueAsync("key", 1, 10)
             .Returns(5);
-        
+
         var result = await _sut.LengthByValueAsync("key", 1, 10);
-        
+
         result.IsRight.Should().BeTrue();
         result.OnRight(l => l.Should().Be(5));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(1);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -260,7 +260,7 @@ internal partial class LoggingRedisSortedSetServiceTests
             e.LogLevel.Should().Be(LogLevel.Information);
         });
     }
-    
+
     [Test]
     public async Task LengthByValueAsync_WhenServiceReturnsLeft_ShouldReturnLeftAndLog()
     {
@@ -268,12 +268,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .LengthByValueAsync("key", 1, 10)
             .Returns(error);
-        
+
         var result = await _sut.LengthByValueAsync("key", 1, 10);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>

--- a/tests/Func.Redis.Tests/SortedSet/LoggingRedisSortedSetService/LoggingRedisSortedSetServiceTests.RangeByScore.cs
+++ b/tests/Func.Redis.Tests/SortedSet/LoggingRedisSortedSetService/LoggingRedisSortedSetServiceTests.RangeByScore.cs
@@ -2,54 +2,56 @@
 internal partial class LoggingRedisSortedSetServiceTests
 {
     [Test]
-    public void Decrement_WhenServiceReturnsRight_ShouldReturnRight()
+    public void RangeByScore_WhenServiceReturnsRight_ShouldReturnRight()
     {
         _mockService
-            .Decrement("some key", "value", 10)
-            .Returns(Unit.Default);
+            .RangeByScore<int>("some key", 1, 10)
+            .Returns(Either<Error, int[]>.Right([1, 2]));
 
-        var result = _sut.Decrement("some key", "value", 10);
+        var result = _sut.RangeByScore<int>("some key", 1, 10);
 
         result.IsRight.Should().BeTrue();
+        result.OnRight(r => r.Should().BeEquivalentTo([1, 2]));
 
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(1);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
         {
-            e.Message.Should().Be("IRedisSortedSetService: decrementing item \"value\" in \"some key\" by 10");
+            e.Message.Should().Be("IRedisSortedSetService: getting range by score from sorted set at \"some key\" with range [1, 10]");
             e.LogLevel.Should().Be(LogLevel.Information);
         });
     }
 
     [Test]
-    public async Task DecrementAsync_WhenServiceReturnsRight_ShouldReturnRight()
+    public async Task RangeByScoreAsync_WhenServiceReturnsRight_ShouldReturnRight()
     {
         _mockService
-            .DecrementAsync("some key", "value", 10)
-            .Returns(Unit.Default);
+            .RangeByScoreAsync<int>("some key", 1, 10)
+            .Returns(Either<Error, int[]>.Right([1, 2]));
 
-        var result = await _sut.DecrementAsync("some key", "value", 10);
+        var result = await _sut.RangeByScoreAsync<int>("some key", 1, 10);
 
         result.IsRight.Should().BeTrue();
+        result.OnRight(r => r.Should().BeEquivalentTo([1, 2]));
 
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(1);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
         {
-            e.Message.Should().Be("IRedisSortedSetService: async decrementing item \"value\" in \"some key\" by 10");
+            e.Message.Should().Be("IRedisSortedSetService: async getting range by score from sorted set at \"some key\" with range [1, 10]");
             e.LogLevel.Should().Be(LogLevel.Information);
         });
     }
 
     [Test]
-    public void Decrement_WhenServiceReturnsLeft_ShouldReturnLeftAndLog()
+    public void RangeByScore_WhenServiceReturnsLeft_ShouldReturnLeftAndLog()
     {
         var error = Error.New("Some error");
         _mockService
-            .Decrement("some key", "value", 10)
-            .Returns(error);
+            .RangeByScore<int>("some key", 1, 10)
+            .Returns(Either<Error, int[]>.Left(error));
 
-        var result = _sut.Decrement("some key", "value", 10);
+        var result = _sut.RangeByScore<int>("some key", 1, 10);
 
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
@@ -58,7 +60,7 @@ internal partial class LoggingRedisSortedSetServiceTests
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
         {
-            e.Message.Should().Be("IRedisSortedSetService: decrementing item \"value\" in \"some key\" by 10");
+            e.Message.Should().Be("IRedisSortedSetService: getting range by score from sorted set at \"some key\" with range [1, 10]");
             e.LogLevel.Should().Be(LogLevel.Information);
         });
         entries[1].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -69,14 +71,14 @@ internal partial class LoggingRedisSortedSetServiceTests
     }
 
     [Test]
-    public async Task DecrementAsync_WhenServiceReturnsLeft_ShouldReturnLeftAndLog()
+    public async Task RangeByScoreAsync_WhenServiceReturnsLeft_ShouldReturnLeftAndLog()
     {
         var error = Error.New("Some error");
         _mockService
-            .DecrementAsync("some key", "value", 10)
-            .Returns(error);
+            .RangeByScoreAsync<int>("some key", 1, 10)
+            .Returns(Either<Error, int[]>.Left(error));
 
-        var result = await _sut.DecrementAsync("some key", "value", 10);
+        var result = await _sut.RangeByScoreAsync<int>("some key", 1, 10);
 
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
@@ -85,7 +87,7 @@ internal partial class LoggingRedisSortedSetServiceTests
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
         {
-            e.Message.Should().Be("IRedisSortedSetService: async decrementing item \"value\" in \"some key\" by 10");
+            e.Message.Should().Be("IRedisSortedSetService: async getting range by score from sorted set at \"some key\" with range [1, 10]");
             e.LogLevel.Should().Be(LogLevel.Information);
         });
         entries[1].Should().BeOfType<LogEntry>().Which.Tee(e =>

--- a/tests/Func.Redis.Tests/SortedSet/LoggingRedisSortedSetService/LoggingRedisSortedSetServiceTests.Rank.cs
+++ b/tests/Func.Redis.Tests/SortedSet/LoggingRedisSortedSetService/LoggingRedisSortedSetServiceTests.Rank.cs
@@ -34,9 +34,9 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .RankAsync("key", value)
             .Returns(10L.ToOption());
-     
+
         var result = await _sut.RankAsync("key", value);
-        
+
         result.IsRight.Should().BeTrue();
         result.OnRight(o =>
         {
@@ -62,7 +62,7 @@ internal partial class LoggingRedisSortedSetServiceTests
             .Returns(error);
 
         var result = _sut.Rank("key", value);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
 
@@ -88,9 +88,9 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .RankAsync("key", value)
             .Returns(error);
-     
+
         var result = await _sut.RankAsync("key", value);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
         var entries = _loggerFactory.Sink.LogEntries.ToArray();

--- a/tests/Func.Redis.Tests/SortedSet/LoggingRedisSortedSetService/LoggingRedisSortedSetServiceTests.Remove.cs
+++ b/tests/Func.Redis.Tests/SortedSet/LoggingRedisSortedSetService/LoggingRedisSortedSetServiceTests.Remove.cs
@@ -29,11 +29,11 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .RemoveAsync("key", value)
             .Returns(Unit.Default);
-     
+
         var result = await _sut.RemoveAsync("key", value);
-        
+
         result.IsRight.Should().BeTrue();
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(1);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -51,12 +51,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .Remove("key", value)
             .Returns(error);
-        
+
         var result = _sut.Remove("key", value);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -79,12 +79,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .RemoveAsync("key", value)
             .Returns(error);
-        
+
         var result = await _sut.RemoveAsync("key", value);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -106,9 +106,9 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .Remove<object>("key", values)
             .Returns(Unit.Default);
-     
+
         var result = _sut.Remove<object>("key", values);
-        
+
         result.IsRight.Should().BeTrue();
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(1);
@@ -118,7 +118,7 @@ internal partial class LoggingRedisSortedSetServiceTests
             e.LogLevel.Should().Be(LogLevel.Information);
         });
     }
-    
+
     [Test]
     public async Task RemoveAsync_WhenServiceReturnsRightForMultipleValues_ShouldReturnRight()
     {
@@ -126,11 +126,11 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .RemoveAsync<object>("key", values)
             .Returns(Unit.Default);
-     
+
         var result = await _sut.RemoveAsync<object>("key", values);
-        
+
         result.IsRight.Should().BeTrue();
-     
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(1);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -148,12 +148,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .Remove<object>("key", values)
             .Returns(error);
-        
+
         var result = _sut.Remove<object>("key", values);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -176,12 +176,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .RemoveAsync<object>("key", values)
             .Returns(error);
-        
+
         var result = await _sut.RemoveAsync<object>("key", values);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -204,9 +204,9 @@ internal partial class LoggingRedisSortedSetServiceTests
             .Returns(Unit.Default);
 
         var result = _sut.RemoveRangeByScore("key", 1.0, 10.0);
-        
+
         result.IsRight.Should().BeTrue();
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(1);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -222,11 +222,11 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .RemoveRangeByScoreAsync("key", 1.0, 10.0)
             .Returns(Unit.Default);
-        
+
         var result = await _sut.RemoveRangeByScoreAsync("key", 1.0, 10.0);
-        
+
         result.IsRight.Should().BeTrue();
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(1);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -243,12 +243,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .RemoveRangeByScore("key", 1.0, 10.0)
             .Returns(error);
-        
+
         var result = _sut.RemoveRangeByScore("key", 1.0, 10.0);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -270,12 +270,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .RemoveRangeByScoreAsync("key", 1.0, 10.0)
             .Returns(error);
-        
+
         var result = await _sut.RemoveRangeByScoreAsync("key", 1.0, 10.0);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -299,9 +299,9 @@ internal partial class LoggingRedisSortedSetServiceTests
             .RemoveRangeByValue("key", min, max)
             .Returns(Unit.Default);
         var result = _sut.RemoveRangeByValue("key", min, max);
-        
+
         result.IsRight.Should().BeTrue();
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(1);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -319,11 +319,11 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .RemoveRangeByValueAsync("key", min, max)
             .Returns(Unit.Default);
-        
+
         var result = await _sut.RemoveRangeByValueAsync("key", min, max);
-        
+
         result.IsRight.Should().BeTrue();
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(1);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -342,12 +342,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .RemoveRangeByValue("key", min, max)
             .Returns(error);
-        
+
         var result = _sut.RemoveRangeByValue("key", min, max);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -371,12 +371,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .RemoveRangeByValueAsync("key", min, max)
             .Returns(error);
-        
+
         var result = await _sut.RemoveRangeByValueAsync("key", min, max);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>

--- a/tests/Func.Redis.Tests/SortedSet/LoggingRedisSortedSetService/LoggingRedisSortedSetServiceTests.Score.cs
+++ b/tests/Func.Redis.Tests/SortedSet/LoggingRedisSortedSetService/LoggingRedisSortedSetServiceTests.Score.cs
@@ -34,9 +34,9 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .ScoreAsync("key", value)
             .Returns(10.0.ToOption());
-     
+
         var result = await _sut.ScoreAsync("key", value);
-        
+
         result.IsRight.Should().BeTrue();
         result.OnRight(o =>
         {
@@ -62,7 +62,7 @@ internal partial class LoggingRedisSortedSetServiceTests
             .Returns(error);
 
         var result = _sut.Score("key", value);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
 
@@ -88,9 +88,9 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .ScoreAsync("key", value)
             .Returns(error);
-     
+
         var result = await _sut.ScoreAsync("key", value);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
         var entries = _loggerFactory.Sink.LogEntries.ToArray();

--- a/tests/Func.Redis.Tests/SortedSet/LoggingRedisSortedSetService/LoggingRedisSortedSetServiceTests.Union.cs
+++ b/tests/Func.Redis.Tests/SortedSet/LoggingRedisSortedSetService/LoggingRedisSortedSetServiceTests.Union.cs
@@ -11,7 +11,7 @@ internal partial class LoggingRedisSortedSetServiceTests
             .Returns(data);
 
         var result = _sut.Union<object>(keys);
-        
+
         result.IsRight.Should().BeTrue();
         result.OnRight(values => values.Should().BeEquivalentTo(data));
 
@@ -32,9 +32,9 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .UnionAsync<object>(keys)
             .Returns(data);
-     
+
         var result = await _sut.UnionAsync<object>(keys);
-        
+
         result.IsRight.Should().BeTrue();
         result.OnRight(values => values.Should().BeEquivalentTo(data));
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
@@ -55,10 +55,10 @@ internal partial class LoggingRedisSortedSetServiceTests
             .Union<object>(keys)
             .Returns(error);
         var result = _sut.Union<object>(keys);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>
@@ -81,12 +81,12 @@ internal partial class LoggingRedisSortedSetServiceTests
         _mockService
             .UnionAsync<object>(keys)
             .Returns(error);
-        
+
         var result = await _sut.UnionAsync<object>(keys);
-        
+
         result.IsLeft.Should().BeTrue();
         result.OnLeft(e => e.Should().Be(error));
-        
+
         var entries = _loggerFactory.Sink.LogEntries.ToArray();
         entries.Should().HaveCount(2);
         entries[0].Should().BeOfType<LogEntry>().Which.Tee(e =>

--- a/tests/Func.Redis.Tests/SortedSet/RedisSortedSetService/RedisSortedSetServiceTests.RangeByScore.cs
+++ b/tests/Func.Redis.Tests/SortedSet/RedisSortedSetService/RedisSortedSetServiceTests.RangeByScore.cs
@@ -1,0 +1,108 @@
+﻿namespace Func.Redis.Tests.SortedSet.RedisSortedSetService;
+internal partial class RedisSortedSetServiceTests
+{
+    [Test]
+    public void RangeByScore_WhenDataArePresent_ShouldReturnCorrectRange()
+    {
+        _mockDb
+            .SortedSetRangeByScore("key", 1, 10)
+            .Returns(["1", "2", "3"]);
+
+        _mockSerDes
+            .Deserialize<int>("1")
+            .Returns(1.ToOption());
+        _mockSerDes
+            .Deserialize<int>("2")
+            .Returns(2.ToOption());
+        _mockSerDes
+            .Deserialize<int>("3")
+            .Returns(Option<int>.None());
+
+        var result = _sut.RangeByScore<int>("key", 1, 10);
+
+        result.IsRight.Should().BeTrue();
+        result.OnRight(r => r.Should().BeEquivalentTo([1, 2]));
+    }
+
+    [Test]
+    public async Task RangeByScoreAsync_WhenDataArePresent_ShouldReturnCorrectRange()
+    {
+        _mockDb
+            .SortedSetRangeByScoreAsync("key", 1, 10)
+            .Returns(["1", "2", "3"]);
+        _mockSerDes
+            .Deserialize<int>("1")
+            .Returns(1.ToOption());
+        _mockSerDes
+            .Deserialize<int>("2")
+            .Returns(2.ToOption());
+        _mockSerDes
+            .Deserialize<int>("3")
+            .Returns(Option<int>.None());
+
+        var result = await _sut.RangeByScoreAsync<int>("key", 1, 10);
+
+        result.IsRight.Should().BeTrue();
+        result.OnRight(r => r.Should().BeEquivalentTo([1, 2]));
+    }
+
+    [Test]
+    public void RangeByScore_WhenDeserializerThrows_ShouldReturnError()
+    {
+        _mockDb
+            .SortedSetRangeByScore("key", 1, 10)
+            .Returns(["1", "2", "3"]);
+        _mockSerDes
+            .Deserialize<int>("1")
+            .Returns(_ => throw new Exception("Deserialization error"));
+
+        var result = _sut.RangeByScore<int>("key", 1, 10);
+
+        result.IsLeft.Should().BeTrue();
+        result.OnLeft(e => e.Should().BeEquivalentTo(Error.New("Deserialization error")));
+    }
+
+    [Test]
+    public async Task RangeByScoreAsync_WhenDeserializerThrows_ShouldReturnError()
+    {
+        _mockDb
+            .SortedSetRangeByScoreAsync("key", 1, 10)
+            .Returns(["1", "2", "3"]);
+        _mockSerDes
+            .Deserialize<int>("1")
+            .Returns(_ => throw new Exception("Deserialization error"));
+
+        var result = await _sut.RangeByScoreAsync<int>("key", 1, 10);
+
+        result.IsLeft.Should().BeTrue();
+        result.OnLeft(e => e.Should().BeEquivalentTo(Error.New("Deserialization error")));
+    }
+
+    [Test]
+    public void RangeByScore_WhenDatabaseThrows_ShouldReturnError()
+    {
+        var exception = new Exception("some message");
+        _mockDb
+            .SortedSetRangeByScore("key", 1, 10)
+            .Returns(_ => throw exception);
+
+        var result = _sut.RangeByScore<int>("key", 1, 10);
+
+        result.IsLeft.Should().BeTrue();
+        result.OnLeft(e => e.Should().BeEquivalentTo(Error.New(exception)));
+    }
+
+    [Test]
+    public async Task RangeByScoreAsync_WhenDatabaseThrows_ShouldReturnError()
+    {
+        var exception = new Exception("some message");
+        _mockDb
+            .SortedSetRangeByScoreAsync("key", 1, 10)
+            .Returns<RedisValue[]>(_ => throw exception);
+
+        var result = await _sut.RangeByScoreAsync<int>("key", 1, 10);
+
+        result.IsLeft.Should().BeTrue();
+        result.OnLeft(e => e.Should().BeEquivalentTo(Error.New(exception)));
+    }
+}


### PR DESCRIPTION
## Pull Request: Introduce Range Queries for Sorted Sets and Add Integration Tests

### Summary

This PR introduces new range query capabilities for Redis sorted sets, specifically the ability to retrieve elements by score range. It also significantly expands integration test coverage across multiple Redis versions and images, ensuring robust compatibility and correctness.

---

### Key Changes

#### 1. **Range Queries for Sorted Sets**
- **New Methods:**  
  - `RangeByScore<T>(string key, double min, double max)` and its async counterpart have been added to `IRedisSortedSetService` and all related implementations (`RedisSortedSetService`, `LoggingRedisSortedSetService`, `KeyTransformerRedisSortedSetService`).
- **Purpose:**  
  - Enables efficient retrieval of elements within a specified score range from a sorted set.
- **Tests:**  
  - Comprehensive unit tests for the new methods, including error handling and deserialization scenarios.

#### 2. **Integration Test Expansion**
- **New Integration Tests:**  
  - Added integration tests for HashSet, Key, List, Set, PubSub, and SortedSet services.
  - Tests now cover Redis 6, 7, 8, and Valkey 8, including Alpine variants.
- **Purpose:**  
  - Ensures compatibility and correctness across multiple Redis versions and distributions.

#### 3. **General Improvements**
- **Test Refactoring:**  
  - Improved naming consistency in test keys using `nameof`.
  - Refactored test data generation for clarity and maintainability.
- **Minor Code Cleanups:**  
  - Whitespace and formatting adjustments for consistency.
  - Use of C# 12 collection expressions (e.g., `[.. Enumerable.Range(...)]`) for brevity.

---

### Motivation

- **Feature Request:**  
  - Support for range queries by score in sorted sets was missing and is essential for many Redis use cases.
- **Reliability:**  
  - Broader integration testing ensures the library works reliably with current and future Redis/Valkey releases.

---

### Impact

- **API:**  
  - Backward compatible. Only new methods added.
- **Tests:**  
  - Substantial increase in test coverage and confidence.
- **Documentation:**  
  - XML comments and summaries updated for new methods.

---

### Checklist

- [x] New feature: Range queries for sorted sets
- [x] Unit and integration tests for new functionality
- [x] Multi-version Redis/Valkey integration test coverage
- [x] Code and test refactoring for clarity
