### PR TITLE
Add some integration tests

### DIFF
--- a/tests/Func.Redis.IntegrationTests/SortedSet/RedisSortedSetServiceIntegrationTest.cs
+++ b/tests/Func.Redis.IntegrationTests/SortedSet/RedisSortedSetServiceIntegrationTest.cs
@@ -18,8 +18,18 @@ internal abstract class RedisSortedSetServiceIntegrationTest(string redisImage) 
     public async Task WhenDataAreNotPresent_AddShouldReturnRightUnit()
     {
         var addResult = await _sut.AddAsync("some key", "some value", 10);
-
         addResult.IsRight.Should().BeTrue();
+
+        var getResult = await _sut.RangeByScoreAsync<string>("some key", 1, 10);
+        getResult.IsRight.Should().BeTrue();
+        getResult.OnRight(o => o.Should().BeEquivalentTo(["some value"]));
+
+        var removeResult = await _sut.RemoveAsync("some key", "some value");
+        removeResult.IsRight.Should().BeTrue();
+
+        getResult = await _sut.RangeByScoreAsync<string>("some key", 1, 10);
+        getResult.IsRight.Should().BeTrue();
+        getResult.OnRight(o => o.Should().BeEmpty());
     }
 
     [Test]


### PR DESCRIPTION
## Pull Request Description

### Summary

This pull request enhances the integration tests for the `RedisSortedSetService` by expanding the test coverage of the `AddAsync` method. The updated test now verifies not only the addition of an element to a sorted set but also the retrieval and removal of that element, ensuring the correctness of the add, get, and remove operations in sequence.

### Details

- **Test Enhancement:**  
  The `WhenDataAreNotPresent_AddShouldReturnRightUnit` test in `RedisSortedSetServiceIntegrationTest.cs` has been extended to:
  - Assert that the added value can be retrieved using `RangeByScoreAsync`.
  - Assert that the value is correctly removed using `RemoveAsync`.
  - Assert that after removal, the value is no longer present in the sorted set.

- **Purpose:**  
  These changes improve the reliability of the integration tests by ensuring that the sorted set operations (`AddAsync`, `RangeByScoreAsync`, and `RemoveAsync`) work together as expected and that the state of the data is consistent after each operation.

### Motivation

- To catch potential regressions in sorted set operations.
- To provide more robust test coverage for the Redis sorted set service.

### Impact

- No production code changes; only test code is affected.
- No breaking changes.
